### PR TITLE
Attempt to create functions before tables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
 FROM alpine:3.8
 
 RUN set -x && \
-    apk add --no-cache bash python3 ca-certificates postgresql-libs postgresql-dev && \
+    apk add --no-cache bash python3 ca-certificates postgresql-libs postgresql-dev libffi-dev && \
     apk add --no-cache --virtual=build-dependencies build-base python3-dev && \
     pip3 install --upgrade --no-cache-dir pip && \
-    pip3 install --no-cache-dir psycopg2-binary migra && \
+    pip3 install poetry && \
+    pip3 install --no-cache-dir psycopg2-binary && \
     apk del build-dependencies postgresql-dev python3-dev && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/*
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
+COPY . /migra
+WORKDIR /migra
+RUN poetry build && ls -l dist/ && pip3 install dist/migra-1.0.tar.gz
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/migra/migra.py
+++ b/migra/migra.py
@@ -94,6 +94,8 @@ class Migration(object):
         self.add(self.changes.pk_constraints(drops_only=True))
         self.add(self.changes.non_mv_indexes(drops_only=True))
 
+        # Related issue: https://github.com/djrobstep/migra/issues/92
+        self.add(self.changes.non_table_selectable_creations()) # TODO(rhomel): not sure if creating functions here breaks other behavior
         self.add(self.changes.tables_only_selectables())
 
         self.add(self.changes.sequences(drops_only=True))
@@ -103,7 +105,6 @@ class Migration(object):
         self.add(self.changes.pk_constraints(creations_only=True))
         self.add(self.changes.non_pk_constraints(creations_only=True))
 
-        self.add(self.changes.non_table_selectable_creations())
         self.add(self.changes.mv_indexes(creations_only=True))
 
         if privileges:


### PR DESCRIPTION
This is a temporary workaround for https://github.com/djrobstep/migra/issues/92

NOTE: The modified Dockerfile will build an Docker image of the local repository source instead of the package on `pip`.

To rebuild from the local source and push images one can use the following:

```
docker build -t some.docker.registry/some-path/migra:latest .
docker push some.docker.registry/some-path/migra:latest
```
